### PR TITLE
Fix documentations url and make curl silent

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 # Examples
 
-- [Vault Dev](https://github.com/hashicorp/vault-guides/tree/f-add-provision-guides/operations/provision-dev/terraform-aws)
-- [Vault Quick Start](https://github.com/hashicorp/vault-guides/tree/f-add-provision-guides/operations/provision-quick-start/terraform-aws)
-- [Vault Best Practices](https://github.com/hashicorp/vault-guides/tree/f-add-provision-guides/operations/provision-best-practices/terraform-aws)
+- [Vault Dev](https://github.com/hashicorp/vault-guides/tree/master/operations/provision-vault/dev/terraform-aws)
+- [Vault Quick Start](https://github.com/hashicorp/vault-guides/tree/master/operations/provision-vault/quick-start/terraform-aws)
+- [Vault Best Practices](https://github.com/hashicorp/vault-guides/tree/master/operations/provision-vault/best-practices/terraform-aws)

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ up.
 below command to accomplish this automatically (we'll use Consul DNS moving
 forward once Vault is unsealed).
 
-  $ ssh -A ${lookup(var.users, var.os)}@$(curl http://127.0.0.1:8500/v1/agent/members | jq -M -r \
+  $ ssh -A ${lookup(var.users, var.os)}@$(curl -s http://127.0.0.1:8500/v1/agent/members | jq -M -r \
       '[.[] | select(.Name | contains ("${var.name}-vault")) | .Addr][0]')
 
 2.) Initialize Vault


### PR DESCRIPTION
Hello, 

I have fix links in documentation to point to the right terraform-aws configuration 
And in the output I have made curl silent.